### PR TITLE
Fixed resource leak in FileUtil

### DIFF
--- a/easycsvmap/src/main/java/com/github/jep42/easycsvmap/util/FileUtil.java
+++ b/easycsvmap/src/main/java/com/github/jep42/easycsvmap/util/FileUtil.java
@@ -33,11 +33,11 @@ public final class FileUtil {
     }
 
     private void initialize() throws IOException {
-        BOMInputStream input = new BOMInputStream(Files.newInputStream(Paths.get(this.filePath)));
-
-        // Fetch BOM (optional) and actual data from the InputStream
-        this.bom = input.getBOM();
-        this.content = IOUtils.toString(input, getCharSet(bom));
+        try (BOMInputStream input = new BOMInputStream(Files.newInputStream(Paths.get(this.filePath)))) {
+            // Fetch BOM (optional) and actual data from the InputStream
+            this.bom = input.getBOM();
+            this.content = IOUtils.toString(input, getCharSet(bom));
+        }
     }
 
     public String getContent() {

--- a/easycsvmap/src/test/java/com/github/jep42/easycsvmap/util/FileUtilTest.java
+++ b/easycsvmap/src/test/java/com/github/jep42/easycsvmap/util/FileUtilTest.java
@@ -1,8 +1,11 @@
 package com.github.jep42.easycsvmap.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
 
 import org.apache.commons.io.ByteOrderMark;
 import org.junit.Test;
@@ -21,12 +24,30 @@ public class FileUtilTest {
 
     @Test
     public void testGetFileUtilFor_WithUTF8ByteOrderMark() throws Exception {
-        String csvFilePath = FileUtil.getSystemResourcePath("com/github/jep42/easycsvmap/no-header-five-lines_UTF-8_BOM.csv");
+        String csvFilePath = FileUtil
+                .getSystemResourcePath("com/github/jep42/easycsvmap/no-header-five-lines_UTF-8_BOM.csv");
 
         FileUtil fileUtilForCsvFile = FileUtil.getFileUtilFor(csvFilePath);
 
         assertEquals(ByteOrderMark.UTF_8, fileUtilForCsvFile.getBom());
         assertNotNull(fileUtilForCsvFile.getContent());
+    }
+
+    @Test
+    public void testGetFileUtilFor_streamClosed() throws Exception {
+
+        // create temp file
+        Path target = Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+        Path source = Paths.get(FileUtil.getSystemResourcePath("com/github/jep42/easycsvmap/header-0-five-lines.csv"));
+        Files.copy(source, target);
+
+        // target was created successfully
+        FileUtil fileUtilForTargetFile = FileUtil.getFileUtilFor(target.toAbsolutePath().toString());
+        assertNotNull(fileUtilForTargetFile.getContent());
+
+        // assure there is no open file handle on target file
+        Files.delete(target);
+        assertFalse(Files.exists(target));
     }
 
 }

--- a/easycsvmap/src/test/java/com/github/jep42/easycsvmap/util/FileUtilTest.java
+++ b/easycsvmap/src/test/java/com/github/jep42/easycsvmap/util/FileUtilTest.java
@@ -1,11 +1,8 @@
 package com.github.jep42.easycsvmap.util;
 
-import static org.junit.Assert.*;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.UUID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import org.apache.commons.io.ByteOrderMark;
 import org.junit.Test;
@@ -24,30 +21,12 @@ public class FileUtilTest {
 
     @Test
     public void testGetFileUtilFor_WithUTF8ByteOrderMark() throws Exception {
-        String csvFilePath = FileUtil
-                .getSystemResourcePath("com/github/jep42/easycsvmap/no-header-five-lines_UTF-8_BOM.csv");
+        String csvFilePath = FileUtil.getSystemResourcePath("com/github/jep42/easycsvmap/no-header-five-lines_UTF-8_BOM.csv");
 
         FileUtil fileUtilForCsvFile = FileUtil.getFileUtilFor(csvFilePath);
 
         assertEquals(ByteOrderMark.UTF_8, fileUtilForCsvFile.getBom());
         assertNotNull(fileUtilForCsvFile.getContent());
-    }
-
-    @Test
-    public void testGetFileUtilFor_streamClosed() throws Exception {
-
-        // create temp file
-        Path target = Paths.get(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
-        Path source = Paths.get(FileUtil.getSystemResourcePath("com/github/jep42/easycsvmap/header-0-five-lines.csv"));
-        Files.copy(source, target);
-
-        // target was created successfully
-        FileUtil fileUtilForTargetFile = FileUtil.getFileUtilFor(target.toAbsolutePath().toString());
-        assertNotNull(fileUtilForTargetFile.getContent());
-
-        // assure there is no open file handle on target file
-        Files.delete(target);
-        assertFalse(Files.exists(target));
     }
 
 }


### PR DESCRIPTION
Based on issue https://github.com/JeP42/robotframework-easycsvmap/issues/4

Added try-with-resource to FileUtil initialization to make use of Java auto-close.